### PR TITLE
fix build errors, replace soda-js with axios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3897,11 +3897,6 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
-    "cookiejar": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.1.tgz",
-      "integrity": "sha1-PRJ1L2rfaKiS8zJDNJK9WBK7Zo8="
-    },
     "copy-concurrently": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
@@ -5999,11 +5994,6 @@
       "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.9.tgz",
       "integrity": "sha512-+x0BMKTYwZcmGmlkHK0GsXkX1+otfEwqu3QitN0wmWuHaZniw3HeIx1k5OjWX3JUHQHlPS4yONol6eokS1ZAWg=="
     },
-    "eventemitter2": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
-      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas="
-    },
     "eventemitter3": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
@@ -6813,11 +6803,6 @@
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
-    },
-    "formidable": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz",
-      "integrity": "sha1-Kz9MQRy7X91pXESEPiojUUpDIxo="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -14297,11 +14282,6 @@
         }
       }
     },
-    "reduce-component": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
-      "integrity": "sha1-4Mk1QsV0UhvqE98PlIjtgqt3xdo="
-    },
     "redux": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.4.tgz",
@@ -15381,15 +15361,6 @@
         }
       }
     },
-    "soda-js": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/soda-js/-/soda-js-0.2.3.tgz",
-      "integrity": "sha1-jUKMN+j9bcGr+aNRyElkOPy6GfI=",
-      "requires": {
-        "eventemitter2": "~0.4.14",
-        "superagent": "~0.21.0"
-      }
-    },
     "sort-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
@@ -15938,113 +15909,6 @@
             "indexes-of": "^1.0.1",
             "uniq": "^1.0.1"
           }
-        }
-      }
-    },
-    "superagent": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-0.21.0.tgz",
-      "integrity": "sha1-+xUCeYR1HucVIgDmzSHNbhml3oc=",
-      "requires": {
-        "component-emitter": "1.1.2",
-        "cookiejar": "2.0.1",
-        "debug": "2",
-        "extend": "~1.2.1",
-        "form-data": "0.1.3",
-        "formidable": "1.0.14",
-        "methods": "1.0.1",
-        "mime": "1.2.11",
-        "qs": "1.2.0",
-        "readable-stream": "1.0.27-1",
-        "reduce-component": "1.0.1"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
-        },
-        "combined-stream": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-          "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
-          "requires": {
-            "delayed-stream": "0.0.5"
-          }
-        },
-        "component-emitter": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-          "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM="
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "delayed-stream": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-          "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8="
-        },
-        "extend": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz",
-          "integrity": "sha1-oPX9bPyDpf5J72mNYOyKYk3UV2w="
-        },
-        "form-data": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.3.tgz",
-          "integrity": "sha1-TuQ0bm61Ni6DRKAgdb2NvYxzc+o=",
-          "requires": {
-            "async": "~0.9.0",
-            "combined-stream": "~0.0.4",
-            "mime": "~1.2.11"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "methods": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz",
-          "integrity": "sha1-dbyRlD3/19oDfPPusO1zoAN80Us="
-        },
-        "mime": {
-          "version": "1.2.11",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-          "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "qs": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.0.tgz",
-          "integrity": "sha1-7Qeb4oaCFH5v2aNMwrDB4OxkU+4="
-        },
-        "readable-stream": {
-          "version": "1.0.27-1",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
-          "integrity": "sha1-a2eYPCA1fO/QfwFlABoW1xDZEHg=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "0.0.1",
   "author": "@cityofsomerville, @itspulp",
   "dependencies": {
+    "axios": "^0.19.0",
     "classnames": "^2.2.6",
     "d3": "^5.14.2",
     "date-fns": "^2.8.1",
@@ -25,8 +26,7 @@
     "react-redux": "^7.1.3",
     "redux": "^4.0.4",
     "redux-thunk": "^2.3.0",
-    "reselect": "^4.0.0",
-    "soda-js": "^0.2.3"
+    "reselect": "^4.0.0"
   },
   "devDependencies": {
     "gatsby-plugin-resolve-src": "^2.0.0",

--- a/src/components/ExploreData.js
+++ b/src/components/ExploreData.js
@@ -1,11 +1,20 @@
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import PropTypes from 'prop-types';
 
 import { BlockContent, DataRow, DataCol } from 'components/DataBlock';
-import Map from 'components/Map';
 import { DATE_PRESETS } from 'data/Constants';
 import ChartContainer from 'charts/ChartContainer';
 import StackedAreaChart from 'charts/StackedAreaChart';
+
+const LazyMap = ({ markers }) => {
+  if (typeof window === 'undefined') return <span>loading...</span>;
+  const Component = lazy(() => import('components/Map'));
+  return (
+    <Suspense fallback={<span>loading...</span>}>
+      <Component markers={markers} />
+    </Suspense>
+  );
+};
 
 class ExploreData extends React.Component {
   constructor(props) {
@@ -113,7 +122,7 @@ class ExploreData extends React.Component {
             />
           </DataCol>
           <DataCol>
-            <Map markers={this.props.mapData} />
+            <LazyMap markers={this.props.mapData} />
           </DataCol>
         </DataRow>
       </BlockContent>

--- a/src/data/cityWork/actions.js
+++ b/src/data/cityWork/actions.js
@@ -25,47 +25,11 @@ export const fetchActionsByDay = ({ startDate, endDate }) => {
       const actions = await getActions({ startDate, endDate });
       dispatch({
         type: types.ACTIONS_BY_DAY_SUCCESS,
-        payload: actions
+        payload: actions.data
       });
     } catch (err) {
       dispatch({
         type: types.ACTIONS_BY_DAY_ERROR,
-        payload: err
-      });
-    }
-  };
-};
-
-export const fetchTickets = ({ startDate, endDate }) => {
-  return async dispatch => {
-    try {
-      const tickets = await getTickets({ startDate, endDate });
-      dispatch({
-        type: types.TICKETS_SUCCESS,
-        payload: tickets
-      });
-    } catch (err) {
-      console.log(err);
-      dispatch({
-        type: types.TICKETS_ERROR,
-        payload: err
-      });
-    }
-  };
-};
-
-export const fetchTypesById = () => {
-  return async dispatch => {
-    try {
-      const typesResponse = await getTypes();
-      dispatch({
-        type: types.TYPES_BY_ID_SUCCESS,
-        payload: typesResponse
-      });
-    } catch (err) {
-      console.log(err);
-      dispatch({
-        type: types.TYPES_BY_ID_ERROR,
         payload: err
       });
     }
@@ -81,14 +45,14 @@ export const fetchTypesTickets = ({ startDate, endDate }) => {
           const typesResponse = await getTypes();
           return dispatch({
             type: types.TYPES_BY_ID_SUCCESS,
-            payload: typesResponse
+            payload: typesResponse.data
           });
         })(),
         (async () => {
           const tickets = await getTickets({ startDate, endDate });
           return dispatch({
             type: types.TICKETS_SUCCESS,
-            payload: tickets
+            payload: tickets.data
           });
         })()
         // once both have been stored, calculate weekly trends
@@ -118,7 +82,7 @@ export const fetchCityWorkExploreData = key => {
       const response = await getCityWorkExploreData(key);
       dispatch({
         type: types.EXPLORE_DATA_SUCCESS,
-        payload: response,
+        payload: response.data,
         key
       });
     } catch (err) {

--- a/src/data/cityWork/requests.js
+++ b/src/data/cityWork/requests.js
@@ -1,17 +1,21 @@
-import soda from 'soda-js';
+import axios from 'axios';
 import format from 'date-fns/format';
 import parseISO from 'date-fns/parseISO';
 
 import { SOCRATA_DATASETS } from 'data/Constants';
 
-const consumer = new soda.Consumer('data.somervillema.gov');
+const instance = axios.create({
+  baseURL: 'https://data.somervillema.gov'
+});
+
+const formatURL = dataset => `/resource/${dataset}.json`;
 
 const formatTimestamp = date => format(date, "yyyy-MM-dd'T'HH:mm:ss.SSS");
 
 const constructDateRangeQuery = ({ startDate, endDate, dateField }) =>
-  `${dateField} >= '${formatTimestamp(
+  `(${dateField} >= '${formatTimestamp(
     startDate
-  )}' and ${dateField} < '${formatTimestamp(endDate)}'`;
+  )}' and ${dateField} < '${formatTimestamp(endDate)}')`;
 
 export const getTickets = async ({ startDate, endDate }) => {
   const dateRange = constructDateRangeQuery({
@@ -20,15 +24,11 @@ export const getTickets = async ({ startDate, endDate }) => {
     dateField: 'last_modified'
   });
 
-  return await new Promise((resolve, reject) => {
-    consumer
-      .query()
-      .withDataset(SOCRATA_DATASETS.Somerville_Services)
-      .where(dateRange)
-      .limit(10000)
-      .getRows()
-      .on('success', resolve)
-      .on('error', reject);
+  return await instance.get(formatURL(SOCRATA_DATASETS.Somerville_Services), {
+    params: {
+      $where: dateRange,
+      $limit: 10000
+    }
   });
 };
 
@@ -39,31 +39,23 @@ export const getActions = async ({ startDate, endDate }) => {
     dateField: 'action_date'
   });
 
-  return await new Promise((resolve, reject) => {
-    consumer
-      .query()
-      .withDataset(SOCRATA_DATASETS.Somerville_Services_Activities)
-      .select(
-        'date_trunc_ymd(action_date) AS action_day, code, action_date, request_id'
-      )
-      .where(dateRange)
-      .where('code = 6 or code = 9')
-      .limit(10000)
-      .getRows()
-      .on('success', resolve)
-      .on('error', reject);
-  });
+  return await instance.get(
+    formatURL(SOCRATA_DATASETS.Somerville_Services_Activities),
+    {
+      params: {
+        $select:
+          'date_trunc_ymd(action_date) AS action_day, code, action_date, request_id',
+        $where: `${dateRange} and (code = 6 or code = 9)`,
+        $limit: 10000
+      }
+    }
+  );
 };
 
 export const getTypes = async () => {
-  return await new Promise((resolve, reject) => {
-    consumer
-      .query()
-      .withDataset(SOCRATA_DATASETS.Somerville_Services_Types)
-      .getRows()
-      .on('success', resolve)
-      .on('error', reject);
-  });
+  return await instance.get(
+    formatURL(SOCRATA_DATASETS.Somerville_Services_Types)
+  );
 };
 
 export const getCityWorkExploreData = async key => {
@@ -76,16 +68,12 @@ export const getCityWorkExploreData = async key => {
   const typeSelection = properties.categories
     .map(id => `type = "${id}"`)
     .join(' or ');
+  const statusSelection = `status = "Closed"`;
 
-  return await new Promise((resolve, reject) => {
-    consumer
-      .query()
-      .withDataset(SOCRATA_DATASETS.Somerville_Services)
-      .where(dateRange)
-      .where(typeSelection)
-      .where('status = "Closed"')
-      .getRows()
-      .on('success', resolve)
-      .on('error', reject);
+  return await instance.get(formatURL(SOCRATA_DATASETS.Somerville_Services), {
+    params: {
+      $where: `${dateRange} and (${typeSelection}) and (${statusSelection})`,
+      $limit: 10000
+    }
   });
 };


### PR DESCRIPTION
Oops! `soda-js`, while useful, hasn't been updated in years and crashes the webpack production build. `leaflet` also crashes the build (when prerendering) but I found a nifty way to only load a dependency if `window` is defined. Site is now built and deployed, although still very much in progress.