### PR TITLE
internal work treemap

### DIFF
--- a/src/charts/ChartContainer.js
+++ b/src/charts/ChartContainer.js
@@ -34,8 +34,8 @@ ChartContainer.propTypes = {
   data: PropTypes.array,
   columns: PropTypes.array,
   name: PropTypes.string.isRequired,
-  chartClass: PropTypes.func.isRequired,
-  cachebust: PropTypes.string
+  chartClass: PropTypes.func.isRequired
+  // cachebust: PropTypes.string
 };
 
 ChartContainer.defaultProps = {

--- a/src/charts/Constants.js
+++ b/src/charts/Constants.js
@@ -1,0 +1,10 @@
+// TODO: audit these colors for usability and contrast
+export const CHART_COLORS = [
+  '#98abc5',
+  '#8a89a6',
+  '#7b6888',
+  '#6b486b',
+  '#a05d56',
+  '#d0743c',
+  '#ff8c00'
+];

--- a/src/charts/GroupedBarChart.js
+++ b/src/charts/GroupedBarChart.js
@@ -1,6 +1,6 @@
 import * as d3 from 'd3';
 
-import { CHART_COLORS } from 'data/Constants';
+import { CHART_COLORS } from 'charts/Constants';
 
 const debounce = (func, delay) => {
   let inDebounce;
@@ -27,7 +27,6 @@ export default class GroupedBarChart {
     this.ratio = 2 / 3;
     this.margin = { top: 10, right: 10, bottom: 20, left: 40 };
 
-    // todo: pick high-contrast, universal palette
     this.color = d3.scaleOrdinal().range(CHART_COLORS);
 
     this.init();

--- a/src/charts/StackedAreaChart.js
+++ b/src/charts/StackedAreaChart.js
@@ -1,6 +1,6 @@
 import * as d3 from 'd3';
 
-import { CHART_COLORS } from 'data/Constants';
+import { CHART_COLORS } from 'charts/Constants';
 
 const debounce = (func, delay) => {
   let inDebounce;
@@ -27,18 +27,7 @@ export default class StackedAreaChart {
     this.ratio = 2 / 3;
     this.margin = { top: 0, right: 20, bottom: 20, left: 20 };
 
-    // todo: pick high-contrast, universal palette
-    this.color = d3
-      .scaleOrdinal()
-      .range([
-        '#98abc5',
-        '#8a89a6',
-        '#7b6888',
-        '#6b486b',
-        '#a05d56',
-        '#d0743c',
-        '#ff8c00'
-      ]);
+    this.color = d3.scaleOrdinal().range(CHART_COLORS);
 
     this.init();
   }

--- a/src/charts/Treemap.js
+++ b/src/charts/Treemap.js
@@ -55,6 +55,11 @@ export default class Treemap {
   cleanChart() {
     window.removeEventListener('resize', this.onResize.bind(this));
     this.targetElement.innerHTML = '';
+
+    const tooltip = document.getElementById('tooltip');
+    if (tooltip) {
+      tooltip.parentNode.removeChild(tooltip);
+    }
   }
 
   init() {
@@ -67,6 +72,12 @@ export default class Treemap {
       .select(`#${self.targetId}`)
       .append('svg:svg')
       .attr('class', 'chart');
+
+    self.tooltip = d3
+      .select('body')
+      .append('div')
+      .attr('class', 'tooltip rounded border p-1 bg-light')
+      .attr('id', 'tooltip');
 
     self.resize();
   }
@@ -97,19 +108,19 @@ export default class Treemap {
       .selectAll('g')
       .data(root.leaves())
       .join('g')
-      .attr('transform', d => `translate(${d.x0},${d.y0})`);
-
-    /*
-    // fix this
-    leaf.append('title').text(
-      d =>
-        `${d
-          .ancestors()
-          .reverse()
-          .map(d => d.data.name)
-          .join('/')}\n${d.value}`
-    );
-    */
+      .attr('transform', d => `translate(${d.x0},${d.y0})`)
+      .style('cursor', 'default')
+      .on('mouseover', d =>
+        self.tooltip
+          .html(`Dept: ${d.data.name}<br/>Tickets: ${d.data.value}`)
+          .style('opacity', 1)
+      )
+      .on('mousemove', d =>
+        self.tooltip
+          .style('top', d3.event.pageY - 10 + 'px')
+          .style('left', d3.event.pageX + 10 + 'px')
+      )
+      .on('mouseout', d => self.tooltip.style('opacity', 0));
 
     leaf
       .append('rect')
@@ -122,7 +133,6 @@ export default class Treemap {
 
     leaf
       .append('text')
-      .attr('clip-path', d => d.clipUid)
       .attr('font-size', 10)
       .attr('x', 3)
       .attr('y', 12)

--- a/src/charts/Treemap.js
+++ b/src/charts/Treemap.js
@@ -99,6 +99,8 @@ export default class Treemap {
       .join('g')
       .attr('transform', d => `translate(${d.x0},${d.y0})`);
 
+    /*
+    // fix this
     leaf.append('title').text(
       d =>
         `${d
@@ -107,38 +109,30 @@ export default class Treemap {
           .map(d => d.data.name)
           .join('/')}\n${d.value}`
     );
+    */
 
     leaf
       .append('rect')
-      // .attr("id", d => (d.leafUid = DOM.uid("leaf")).id)
       .attr('fill', d => {
         while (d.depth > 1) d = d.parent;
         return self.color(d.data.name);
       })
-      .attr('fill-opacity', 0.6)
       .attr('width', d => d.x1 - d.x0)
       .attr('height', d => d.y1 - d.y0);
 
     leaf
-      .append('clipPath')
-      // .attr("id", d => (d.clipUid = DOM.uid("clip")).id)
-      .append('use');
-    // .attr("xlink:href", d => d.leafUid.href);
+      .append('text')
+      .attr('clip-path', d => d.clipUid)
+      .attr('font-size', 10)
+      .attr('x', 3)
+      .attr('y', 12)
+      .text(d => `${d.data.name}`);
 
     leaf
       .append('text')
-      // .attr("clip-path", d => d.clipUid)
-      .selectAll('tspan')
-      .data(d => d.data.name.split(/(?=[A-Z][^A-Z])/g).concat(d.value))
-      .join('tspan')
+      .attr('font-size', 10)
       .attr('x', 3)
-      .attr(
-        'y',
-        (d, i, nodes) => `${(i === nodes.length - 1) * 0.3 + 1.1 + i * 0.9}em`
-      )
-      .attr('fill-opacity', (d, i, nodes) =>
-        i === nodes.length - 1 ? 0.7 : null
-      )
-      .text(d => d);
+      .attr('y', 22)
+      .text(d => `${d.data.value}`);
   }
 }

--- a/src/charts/Treemap.js
+++ b/src/charts/Treemap.js
@@ -1,0 +1,144 @@
+import * as d3 from 'd3';
+
+import { CHART_COLORS } from 'charts/Constants';
+
+const debounce = (func, delay) => {
+  let inDebounce;
+  return function() {
+    const context = this;
+    const args = arguments;
+    clearTimeout(inDebounce);
+    inDebounce = setTimeout(() => func.apply(context, args), delay);
+  };
+};
+
+export default class Treemap {
+  constructor({ data, targetId }) {
+    this.data = {
+      name: 'Treemap',
+      children: data
+    };
+    this.groupKey = 'date';
+
+    this.targetId = targetId;
+    this.targetElement = document.getElementById(targetId);
+
+    this.containerWidth = 800;
+    this.width = 800;
+    this.height = 500;
+    this.ratio = 2 / 3;
+    this.margin = { top: 0, right: 0, bottom: 0, left: 0 };
+
+    this.color = d3.scaleOrdinal().range(CHART_COLORS);
+
+    this.init();
+  }
+
+  resize() {
+    const containerWidth = this.targetElement.offsetWidth;
+
+    if (containerWidth !== this.containerWidth) {
+      this.width = containerWidth - this.margin.left - this.margin.right;
+      this.height =
+        containerWidth * this.ratio - this.margin.top - this.margin.bottom;
+      this.renderChart();
+    }
+  }
+
+  onResize() {
+    const fn = event => {
+      this.resize();
+    };
+    debounce(fn.bind(this), 1000)();
+  }
+
+  cleanChart() {
+    window.removeEventListener('resize', this.onResize.bind(this));
+    this.targetElement.innerHTML = '';
+  }
+
+  init() {
+    const self = this;
+    window.addEventListener('resize', this.onResize.bind(this));
+
+    self.cleanChart();
+
+    self.chart = d3
+      .select(`#${self.targetId}`)
+      .append('svg:svg')
+      .attr('class', 'chart');
+
+    self.resize();
+  }
+
+  renderChart() {
+    const self = this;
+
+    self.chart
+      .attr('width', self.width + self.margin.right + self.margin.left)
+      .attr('height', self.height + self.margin.top + self.margin.bottom);
+
+    const treemap = data =>
+      d3
+        .treemap()
+        .tile(d3.treemapSquarify)
+        .size([self.width, self.height])
+        .padding(1)
+        .round(true)(
+        d3
+          .hierarchy(self.data)
+          .sum(d => d.value)
+          .sort((a, b) => b.value - a.value)
+      );
+
+    const root = treemap(self.data);
+
+    const leaf = self.chart
+      .selectAll('g')
+      .data(root.leaves())
+      .join('g')
+      .attr('transform', d => `translate(${d.x0},${d.y0})`);
+
+    leaf.append('title').text(
+      d =>
+        `${d
+          .ancestors()
+          .reverse()
+          .map(d => d.data.name)
+          .join('/')}\n${d.value}`
+    );
+
+    leaf
+      .append('rect')
+      // .attr("id", d => (d.leafUid = DOM.uid("leaf")).id)
+      .attr('fill', d => {
+        while (d.depth > 1) d = d.parent;
+        return self.color(d.data.name);
+      })
+      .attr('fill-opacity', 0.6)
+      .attr('width', d => d.x1 - d.x0)
+      .attr('height', d => d.y1 - d.y0);
+
+    leaf
+      .append('clipPath')
+      // .attr("id", d => (d.clipUid = DOM.uid("clip")).id)
+      .append('use');
+    // .attr("xlink:href", d => d.leafUid.href);
+
+    leaf
+      .append('text')
+      // .attr("clip-path", d => d.clipUid)
+      .selectAll('tspan')
+      .data(d => d.data.name.split(/(?=[A-Z][^A-Z])/g).concat(d.value))
+      .join('tspan')
+      .attr('x', 3)
+      .attr(
+        'y',
+        (d, i, nodes) => `${(i === nodes.length - 1) * 0.3 + 1.1 + i * 0.9}em`
+      )
+      .attr('fill-opacity', (d, i, nodes) =>
+        i === nodes.length - 1 ? 0.7 : null
+      )
+      .text(d => d);
+  }
+}

--- a/src/components/CityWork/InternalWork.js
+++ b/src/components/CityWork/InternalWork.js
@@ -7,7 +7,12 @@ import {
   DataCol,
   WeeklyTrends
 } from 'components/DataBlock';
-import { getInternalWeeklyTrends } from 'data/cityWork/selectors';
+import ChartContainer from 'charts/ChartContainer';
+import Treemap from 'charts/Treemap';
+import {
+  getInternalWeeklyTrends,
+  getInternalTreemapData
+} from 'data/cityWork/selectors';
 import { getBaseCategory } from 'data/BaseCategories';
 
 const InternalWork = ({ internalWeeklyTrends, internalTreemapData }) => (
@@ -19,8 +24,12 @@ const InternalWork = ({ internalWeeklyTrends, internalTreemapData }) => (
     </p>
     <DataRow>
       <DataCol>
-        {/* chart: pass in internalTreemapData here */}
-        treemap showing: internally generated work by category
+        <ChartContainer
+          chartClass={Treemap}
+          data={internalTreemapData}
+          name="internal_treemap"
+          cachebust={internalTreemapData.length}
+        />
       </DataCol>
       <WeeklyTrends metrics={internalWeeklyTrends} />
     </DataRow>
@@ -29,6 +38,9 @@ const InternalWork = ({ internalWeeklyTrends, internalTreemapData }) => (
 
 export default connect(state => {
   let internalWeeklyTrends = getInternalWeeklyTrends(state);
+
+  // todo: consider moving this logic to the selector
+  // but will the entire images be stored in memory?
   internalWeeklyTrends = internalWeeklyTrends.map(category => {
     const ancestor = getBaseCategory(category.ancestor);
     return {
@@ -40,6 +52,6 @@ export default connect(state => {
   return {
     internalWeeklyTrends,
     // also need a selector for chart data here
-    internalTreemapData: []
+    internalTreemapData: getInternalTreemapData(state)
   };
 })(InternalWork);

--- a/src/components/CityWork/InternalWork.js
+++ b/src/components/CityWork/InternalWork.js
@@ -18,9 +18,11 @@ import { getBaseCategory } from 'data/BaseCategories';
 const InternalWork = ({ internalWeeklyTrends, internalTreemapData }) => (
   <BlockContent>
     <p>
-      Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo
-      ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis
-      dis parturient montes, nascetur ridiculus mus.
+      At the same time that they respond to 311 reports, city workers are also
+      proactive about finding work that needs to be done, reporting it, and
+      completing it. This section explores trends in tickets filed internally
+      over the past 7 days. The treemap shows internal tickets completed in the
+      last 7 days grouped by department.
     </p>
     <DataRow>
       <DataCol>

--- a/src/data/Constants.js
+++ b/src/data/Constants.js
@@ -34,13 +34,3 @@ export const DATE_PRESETS = {
     endDate: format(endOfYesterday(), SOCRATA_TIMESTAMP)
   }
 };
-
-export const CHART_COLORS = [
-  '#98abc5',
-  '#8a89a6',
-  '#7b6888',
-  '#6b486b',
-  '#a05d56',
-  '#d0743c',
-  '#ff8c00'
-];

--- a/src/data/cityWork/selectors.js
+++ b/src/data/cityWork/selectors.js
@@ -252,10 +252,6 @@ export const getInternalTreemapData = createSelector(
     data = Object.keys(byDept).map(key => {
       return {
         name: key,
-        // children: byDept[key].map(category => ({
-        //   name: category.label,
-        //   value: category.thisWeekCount
-        // }))
         value: byDept[key].reduce(
           (memo, category) => memo + category.thisWeekCount,
           0
@@ -263,11 +259,6 @@ export const getInternalTreemapData = createSelector(
       };
     });
 
-    // [
-    //   name: 'Dept',
-    //   children: [all tickets for that dept]
-    // ]
-    console.log(data);
     return data;
   }
 );

--- a/src/data/cityWork/selectors.js
+++ b/src/data/cityWork/selectors.js
@@ -230,3 +230,44 @@ export const getInternalWeeklyTrends = createSelector(
     return selection;
   }
 );
+
+const groupBy = (arr, index) =>
+  arr.reduce((memo, item) => {
+    if (!memo[item[index]]) {
+      memo[item[index]] = [];
+    }
+    memo[item[index]].push(item);
+    return memo;
+  }, {});
+
+export const getInternalTreemapData = createSelector(
+  weeklyTrendsSelector,
+  weeklyTrends => {
+    let data = {};
+    const byDept = groupBy(
+      weeklyTrends.filter(trend => isServiceRequest(trend.type)),
+      'dept'
+    );
+
+    data = Object.keys(byDept).map(key => {
+      return {
+        name: key,
+        // children: byDept[key].map(category => ({
+        //   name: category.label,
+        //   value: category.thisWeekCount
+        // }))
+        value: byDept[key].reduce(
+          (memo, category) => memo + category.thisWeekCount,
+          0
+        )
+      };
+    });
+
+    // [
+    //   name: 'Dept',
+    //   children: [all tickets for that dept]
+    // ]
+    console.log(data);
+    return data;
+  }
+);

--- a/src/data/cityWork/utils.js
+++ b/src/data/cityWork/utils.js
@@ -40,6 +40,7 @@ export const getWeeklyTrends = (types, tickets) => {
           label: types[key].name,
           type: key,
           ancestor: types[key].ancestor_id,
+          dept: ticketsByWeek.thisWeek[key][0].dept,
           thisWeekCount,
           lastWeekCount
         };


### PR DESCRIPTION
Shows the past week's tickets closed by department using a treemap. When hovered, a tooltip appears showing further detail. The treemap is segmented by department rather than ticket type. We can segment by ticket type instead, but it results in many more boxes which can be very small and hard to read.

![image](https://user-images.githubusercontent.com/491289/71682992-46ba9f00-2d5f-11ea-8619-d5cae94fc22f.png)
