### PR TITLE
data explorer improvements

### DIFF
--- a/src/charts/ChartContainer.js
+++ b/src/charts/ChartContainer.js
@@ -11,7 +11,6 @@ export default class ChartContainer extends React.Component {
     if (this.props.data && this.props.data.length) {
       this.chart = new this.props.chartClass({
         data: this.props.data,
-        columns: this.props.columns,
         targetId: `chart-container-${this.props.name}`
       });
     }
@@ -25,7 +24,6 @@ export default class ChartContainer extends React.Component {
     if (this.props.cachebust !== prevProps.cachebust) {
       this.chart = new this.props.chartClass({
         data: this.props.data,
-        columns: this.props.columns,
         targetId: `chart-container-${this.props.name}`
       });
     }

--- a/src/charts/Constants.js
+++ b/src/charts/Constants.js
@@ -17,21 +17,8 @@ export const CHART_COLORS = [
   '#64aa8a'
 ];
 
-// export const CHART_COLORS_2 = [
-//   { background: '#002b83', color: 'white' },
-//   { background: '#3b9bcd', color: 'white' },
-//   { background: '#b13133', color: 'white' },
-//   { background: '#c68740', color: 'white' },
-//   { background: '#347a5a', color: 'white' },
-
-//   { background: '#305bb8', color: 'black' },
-//   { background: '#6bbbfd', color: 'black' },
-//   { background: '#e16163', color: 'black' },
-//   { background: '#f6b770', color: 'black' },
-//   { background: '#64aa8a', color: 'black' }
-// ];
-
 export const CHART_COLORS_2 = [
+  // d3.schemeCategory10
   { background: '#1f77b4', color: 'white' },
   { background: '#ff7f0e', color: 'white' },
   { background: '#2ca02c', color: 'white' },
@@ -41,7 +28,16 @@ export const CHART_COLORS_2 = [
   { background: '#e377c2', color: 'white' },
   { background: '#7f7f7f', color: 'white' },
   { background: '#bcbd22', color: 'black' },
-  { background: '#17becf', color: 'black' }
+  { background: '#17becf', color: 'black' },
+  // d3.schemeDark2
+  { background: '#1b9e77', color: 'white' },
+  { background: '#d95f02', color: 'white' },
+  { background: '#7570b3', color: 'white' },
+  { background: '#e7298a', color: 'white' },
+  { background: '#66a61e', color: 'white' },
+  { background: '#e6ab02', color: 'black' },
+  { background: '#a6761d', color: 'white' },
+  { background: '#666666', color: 'white' }
 ];
 
 export const HEATMAP_COLORS = [

--- a/src/charts/Constants.js
+++ b/src/charts/Constants.js
@@ -17,6 +17,20 @@ export const CHART_COLORS = [
   '#64aa8a'
 ];
 
+export const CHART_COLORS_2 = [
+  { background: '#002b83', color: 'white' },
+  { background: '#3b9bcd', color: 'white' },
+  { background: '#b13133', color: 'white' },
+  { background: '#c68740', color: 'white' },
+  { background: '#347a5a', color: 'white' },
+
+  { background: '#305bb8', color: 'black' },
+  { background: '#6bbbfd', color: 'black' },
+  { background: '#e16163', color: 'black' },
+  { background: '#f6b770', color: 'black' },
+  { background: '#64aa8a', color: 'black' }
+];
+
 export const HEATMAP_COLORS = [
   { background: '#eff3ff', color: 'black' },
   { background: '#bdd7e7', color: 'black' },

--- a/src/charts/Constants.js
+++ b/src/charts/Constants.js
@@ -17,18 +17,31 @@ export const CHART_COLORS = [
   '#64aa8a'
 ];
 
-export const CHART_COLORS_2 = [
-  { background: '#002b83', color: 'white' },
-  { background: '#3b9bcd', color: 'white' },
-  { background: '#b13133', color: 'white' },
-  { background: '#c68740', color: 'white' },
-  { background: '#347a5a', color: 'white' },
+// export const CHART_COLORS_2 = [
+//   { background: '#002b83', color: 'white' },
+//   { background: '#3b9bcd', color: 'white' },
+//   { background: '#b13133', color: 'white' },
+//   { background: '#c68740', color: 'white' },
+//   { background: '#347a5a', color: 'white' },
 
-  { background: '#305bb8', color: 'black' },
-  { background: '#6bbbfd', color: 'black' },
-  { background: '#e16163', color: 'black' },
-  { background: '#f6b770', color: 'black' },
-  { background: '#64aa8a', color: 'black' }
+//   { background: '#305bb8', color: 'black' },
+//   { background: '#6bbbfd', color: 'black' },
+//   { background: '#e16163', color: 'black' },
+//   { background: '#f6b770', color: 'black' },
+//   { background: '#64aa8a', color: 'black' }
+// ];
+
+export const CHART_COLORS_2 = [
+  { background: '#1f77b4', color: 'white' },
+  { background: '#ff7f0e', color: 'white' },
+  { background: '#2ca02c', color: 'white' },
+  { background: '#d62728', color: 'white' },
+  { background: '#9467bd', color: 'white' },
+  { background: '#8c564b', color: 'white' },
+  { background: '#e377c2', color: 'white' },
+  { background: '#7f7f7f', color: 'white' },
+  { background: '#bcbd22', color: 'black' },
+  { background: '#17becf', color: 'black' }
 ];
 
 export const HEATMAP_COLORS = [

--- a/src/charts/StackedAreaChart.js
+++ b/src/charts/StackedAreaChart.js
@@ -1,69 +1,24 @@
 import * as d3 from 'd3';
 
+import Chart from 'charts/Chart';
 import { CHART_COLORS } from 'charts/Constants';
 
-const debounce = (func, delay) => {
-  let inDebounce;
-  return function() {
-    const context = this;
-    const args = arguments;
-    clearTimeout(inDebounce);
-    inDebounce = setTimeout(() => func.apply(context, args), delay);
-  };
-};
-
-export default class StackedAreaChart {
-  constructor({ data, columns, targetId }) {
-    this.data = data;
-    this.columns = columns;
+export default class StackedAreaChart extends Chart {
+  constructor(args) {
+    super({
+      ...args,
+      legend: true,
+      margin: { top: 0, right: 20, bottom: 20, left: 30 }
+    });
+    this.columns = args.columns;
     this.groupKey = 'date';
-
-    this.targetId = targetId;
-    this.targetElement = document.getElementById(targetId);
-
-    this.containerWidth = 800;
-    this.width = 800;
-    this.height = 500;
-    this.ratio = 2 / 3;
-    this.margin = { top: 0, right: 20, bottom: 20, left: 30 };
 
     this.color = d3.scaleOrdinal().range(CHART_COLORS);
     this.init();
   }
 
-  resize() {
-    const containerWidth = this.targetElement.offsetWidth;
-
-    if (containerWidth !== this.containerWidth) {
-      this.width = containerWidth - this.margin.left - this.margin.right;
-      this.height =
-        containerWidth * this.ratio - this.margin.top - this.margin.bottom;
-
-      this.renderChart();
-    }
-  }
-
-  onResize() {
-    const fn = event => {
-      this.resize();
-    };
-    debounce(fn.bind(this), 1000)();
-  }
-
-  cleanChart() {
-    window.removeEventListener('resize', this.onResize.bind(this));
-    this.targetElement.innerHTML = '';
-  }
-
   init() {
     const self = this;
-    self.cleanChart();
-    window.addEventListener('resize', this.onResize.bind(this));
-
-    self.chart = d3
-      .select(`#${self.targetId}`)
-      .append('svg:svg')
-      .attr('class', 'chart');
 
     self.main = self.chart
       .append('g')

--- a/src/charts/StackedBarChart.js
+++ b/src/charts/StackedBarChart.js
@@ -10,9 +10,10 @@ export default class StackedBarChart extends Chart {
       legend: true,
       margin: { top: 0, right: 20, bottom: 20, left: 30 }
     });
-    this.columns = args.columns;
+    this.columns = args.data.columns;
+    this.data = args.data.data;
+    this.types = args.data.types;
 
-    this.color = d3.scaleOrdinal().range(CHART_COLORS);
     this.init();
   }
 
@@ -33,6 +34,14 @@ export default class StackedBarChart extends Chart {
     }
   }
 
+  color(key) {
+    let color = 'black';
+    if (this.types[key]) {
+      color = this.types[key].color.background;
+    }
+    return color;
+  }
+
   renderChart() {
     const self = this;
 
@@ -49,16 +58,6 @@ export default class StackedBarChart extends Chart {
 
     const series = stack(self.data);
 
-    // set up the x scale
-    const xScale = d3
-      .scaleTime()
-      .domain([
-        new Date(self.columns[0]),
-        new Date(self.columns[self.columns.length - 1])
-      ])
-      // .domain(self.columns.map(col => new Date(col)))
-      .range([0, self.width]);
-
     // set up the y scale
     const yScale = d3
       .scaleLinear()
@@ -67,9 +66,6 @@ export default class StackedBarChart extends Chart {
         d3.max(series, series => d3.max(series, d => d[1]))
       ])
       .range([self.height - self.margin.bottom - self.margin.top, 0]);
-
-    // color scale
-    const cScale = d3.scaleOrdinal().range(CHART_COLORS);
 
     const x = d3
       .scaleBand()
@@ -81,7 +77,7 @@ export default class StackedBarChart extends Chart {
     const xAxis = d3
       .axisBottom(x)
       .ticks(7)
-      .tickFormat(d3.timeFormat('%Y-%m-%d'));
+      .tickFormat(d => d3.timeFormat('%b %d')(d3.isoParse(d)));
 
     // left axis generator
     const yAxis = d3.axisLeft().scale(yScale);

--- a/src/charts/StackedBarChart.js
+++ b/src/charts/StackedBarChart.js
@@ -47,13 +47,19 @@ export default class StackedBarChart extends Chart {
   }
 
   getTooltip(d) {
-    const rows = [
-      `<b>Date</b>: ${this.formatDate(d.date)}`,
-      ...d.data.map(category => {
-        return `<b>${category.key}:</b> ${category.data.data[category.key]}`;
-      })
-    ].join('<br/>');
-    return rows;
+    return d.data
+      .reduce(
+        (memo, type) => {
+          let rows = memo;
+          const count = type.data.data[type.key];
+          if (count) {
+            rows = [...memo, `<b>${type.key}:</b> ${count}`];
+          }
+          return rows;
+        },
+        [`<b>Date</b>: ${this.formatDate(d.date)}`]
+      )
+      .join('<br/>');
   }
 
   renderChart() {

--- a/src/charts/StackedBarChart.js
+++ b/src/charts/StackedBarChart.js
@@ -42,6 +42,20 @@ export default class StackedBarChart extends Chart {
     return color;
   }
 
+  formatDate(date) {
+    return d3.timeFormat('%b %d')(d3.isoParse(date));
+  }
+
+  getTooltip(d) {
+    const rows = [
+      `<b>Date</b>: ${this.formatDate(d.date)}`,
+      ...d.data.map(category => {
+        return `<b>${category.key}:</b> ${category.data.data[category.key]}`;
+      })
+    ].join('<br/>');
+    return rows;
+  }
+
   renderChart() {
     const self = this;
 
@@ -77,7 +91,7 @@ export default class StackedBarChart extends Chart {
     const xAxis = d3
       .axisBottom(x)
       .ticks(7)
-      .tickFormat(d => d3.timeFormat('%b %d')(d3.isoParse(d)));
+      .tickFormat(d => self.formatDate(d));
 
     // left axis generator
     const yAxis = d3.axisLeft().scale(yScale);
@@ -110,7 +124,7 @@ export default class StackedBarChart extends Chart {
       .data(sortedStackedSeries)
       .join('g')
       .on('mouseover', d => {
-        self.tooltip.html(`Date: ${d.date}`).style('opacity', 1);
+        self.tooltip.html(self.getTooltip(d)).style('opacity', 1);
       })
       .on('mousemove', d =>
         self.tooltip

--- a/src/charts/StackedBarChart.js
+++ b/src/charts/StackedBarChart.js
@@ -1,0 +1,137 @@
+import * as d3 from 'd3';
+
+import Chart from 'charts/Chart';
+import { CHART_COLORS } from 'charts/Constants';
+
+export default class StackedBarChart extends Chart {
+  constructor(args) {
+    super({
+      ...args,
+      legend: true,
+      margin: { top: 0, right: 20, bottom: 20, left: 30 }
+    });
+    this.columns = args.columns;
+
+    this.color = d3.scaleOrdinal().range(CHART_COLORS);
+    this.init();
+  }
+
+  init() {
+    const self = this;
+
+    self.main = self.chart
+      .append('g')
+      .attr('class', 'main')
+      .attr('transform', `translate(${self.margin.left}, ${self.margin.top})`);
+
+    self.xAxis = self.chart.append('g');
+
+    self.yAxis = self.chart.append('g');
+
+    if (self.data.length) {
+      self.resize();
+    }
+  }
+
+  renderChart() {
+    const self = this;
+
+    self.chart
+      .attr('width', self.width + self.margin.right + self.margin.left)
+      .attr('height', self.height + self.margin.top + self.margin.bottom);
+
+    const keys = Object.keys(self.data[0]).filter(key => key !== 'date');
+
+    const stack = d3
+      .stack()
+      .keys(keys)
+      .order(d3.stackOrderDescending); // so that the largest grouping is stacked below the others
+
+    const series = stack(self.data);
+
+    // set up the x scale
+    const xScale = d3
+      .scaleTime()
+      .domain([
+        new Date(self.columns[0]),
+        new Date(self.columns[self.columns.length - 1])
+      ])
+      // .domain(self.columns.map(col => new Date(col)))
+      .range([0, self.width]);
+
+    // set up the y scale
+    const yScale = d3
+      .scaleLinear()
+      .domain([
+        d3.min(series, series => d3.min(series, d => d[0])),
+        d3.max(series, series => d3.max(series, d => d[1]))
+      ])
+      .range([self.height - self.margin.bottom - self.margin.top, 0]);
+
+    // color scale
+    const cScale = d3.scaleOrdinal().range(CHART_COLORS);
+
+    const x = d3
+      .scaleBand()
+      .domain(self.columns)
+      .range([0, self.width])
+      .paddingInner(0.1);
+
+    // bottom axis generator
+    const xAxis = d3
+      .axisBottom(x)
+      .ticks(7)
+      .tickFormat(d3.timeFormat('%Y-%m-%d'));
+
+    // left axis generator
+    const yAxis = d3.axisLeft().scale(yScale);
+
+    self.xAxis
+      .attr(
+        'transform',
+        `translate(${self.margin.left}, ${self.height - self.margin.bottom})`
+      )
+      .call(xAxis);
+
+    self.yAxis
+      .attr('transform', `translate(${self.margin.left},${self.margin.top})`)
+      .call(yAxis);
+
+    const sortedStackedSeries = self.columns.map((day, index) => {
+      return {
+        data: series.map(type => ({
+          data: type[index],
+          key: type.key
+        })),
+        date: day
+      };
+    });
+
+    self.dataContainer = self.chart
+      .append('g')
+      .attr('transform', d => `translate(${self.margin.left + 1},0)`)
+      .selectAll('g')
+      .data(sortedStackedSeries)
+      .join('g')
+      .on('mouseover', d => {
+        self.tooltip.html(`Date: ${d.date}`).style('opacity', 1);
+      })
+      .on('mousemove', d =>
+        self.tooltip
+          .style('top', d3.event.pageY - 10 + 'px')
+          .style('left', d3.event.pageX + 10 + 'px')
+      )
+      .on('mouseout', d => self.tooltip.style('opacity', 0))
+      .attr('transform', d => `translate(${x(d.date)},0)`);
+
+    self.bars = self.dataContainer
+      .selectAll('rect')
+      .data(d => d.data)
+      .join('rect')
+      .attr('fill', d => self.color(d.key))
+      .attr('x', 0)
+      .attr('y', d => yScale(d.data[1]))
+      .attr('width', x.bandwidth())
+      .attr('height', d => Math.abs(yScale(d.data[1]) - yScale(d.data[0])));
+  }
+}

--- a/src/components/CityWork/CityWorkExploreData.js
+++ b/src/components/CityWork/CityWorkExploreData.js
@@ -6,7 +6,8 @@ import {
   getChartData,
   getCategoryNames,
   getAllWeeklyTrends,
-  getCategoryHierarchy
+  getCategoryHierarchy,
+  getLegendData
 } from 'data/cityWork/selectors';
 import ExploreData from 'components/ExploreData';
 
@@ -37,7 +38,8 @@ export default connect(
       mapData: getMapData(state),
       chartData: getChartData(state),
       typesById: state.cityWork.typesById,
-      selectedCategoryNames: getCategoryNames(state)
+      selectedCategoryNames: getCategoryNames(state),
+      legendData: getLegendData(state)
     };
   },
   {

--- a/src/components/ExploreData.js
+++ b/src/components/ExploreData.js
@@ -116,8 +116,7 @@ class ExploreData extends React.Component {
         <DataRow>
           <DataCol>
             <ChartContainer
-              data={this.props.chartData.data}
-              columns={this.props.chartData.columns}
+              data={this.props.chartData}
               chartClass={StackedBarChart}
               name={`explore-data-${this.props.namespace}`}
               cachebust={this.props.params}

--- a/src/components/ExploreData.js
+++ b/src/components/ExploreData.js
@@ -136,8 +136,9 @@ class ExploreData extends React.Component {
             {this.props.legendData
               ? this.props.legendData.map(category => (
                   <li
-                    className="d-flex align-items-center mb-2"
+                    className="d-flex align-items-center mb-2 pr-1"
                     style={{ width: '10rem' }}
+                    key={category.name}
                   >
                     <div
                       className="d-inline-block mr-2"

--- a/src/components/ExploreData.js
+++ b/src/components/ExploreData.js
@@ -127,6 +127,35 @@ class ExploreData extends React.Component {
             <LazyMap markers={this.props.mapData} />
           </DataCol>
         </DataRow>
+        <div
+          className="border bg-light mt-2 py-2 px-3"
+          style={{ fontSize: '0.7rem' }}
+        >
+          <span className="d-block h5 mb-2">Legend</span>
+          <ul className="list-unstyled mb-0 d-flex flex-wrap align-items-center">
+            {this.props.legendData
+              ? this.props.legendData.map(category => (
+                  <li
+                    className="d-flex align-items-center mb-2"
+                    style={{ width: '10rem' }}
+                  >
+                    <div
+                      className="d-inline-block mr-2"
+                      style={{
+                        width: '1.8rem',
+                        minWidth: '1.8rem',
+                        height: '1.8rem',
+                        background: category.color.background
+                      }}
+                    ></div>
+                    <span className="flex-shrink-1 text-break">
+                      {category.name}
+                    </span>
+                  </li>
+                ))
+              : null}
+          </ul>
+        </div>
       </BlockContent>
     );
   }
@@ -146,7 +175,8 @@ ExploreData.propTypes = {
   params: PropTypes.string,
   mapData: PropTypes.array.isRequired,
 
-  fetchData: PropTypes.func.isRequired
+  fetchData: PropTypes.func.isRequired,
+  legendData: PropTypes.shape()
 };
 
 export default ExploreData;

--- a/src/components/ExploreData.js
+++ b/src/components/ExploreData.js
@@ -5,7 +5,7 @@ import listify from 'listify';
 import { BlockContent, DataRow, DataCol } from 'components/DataBlock';
 import { DATE_PRESETS } from 'data/Constants';
 import ChartContainer from 'charts/ChartContainer';
-import StackedAreaChart from 'charts/StackedAreaChart';
+import StackedBarChart from 'charts/StackedBarChart';
 
 const LazyMap = ({ markers }) => {
   if (typeof window === 'undefined') return <span>loading...</span>;
@@ -118,7 +118,7 @@ class ExploreData extends React.Component {
             <ChartContainer
               data={this.props.chartData.data}
               columns={this.props.chartData.columns}
-              chartClass={StackedAreaChart}
+              chartClass={StackedBarChart}
               name={`explore-data-${this.props.namespace}`}
               cachebust={this.props.params}
             />

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -3,8 +3,14 @@ import { Map, CircleMarker, Popup, TileLayer } from 'react-leaflet';
 
 const position = [42.3947, -71.10548];
 
-const MapMarker = ({ lat, lng, id, title, date }) => (
-  <CircleMarker radius={6} center={{ lat, lng }}>
+const MapMarker = ({ lat, lng, id, title, date, color }) => (
+  <CircleMarker
+    radius={6}
+    center={{ lat, lng }}
+    color={color ? color.background : null}
+    fillOpacity={0.5}
+    weight={1}
+  >
     <Popup>
       <p>
         <strong>Type: </strong>
@@ -38,6 +44,7 @@ const ExploreDataMap = ({ markers }) => (
           id={marker.id}
           title={marker.title}
           date={marker.date}
+          color={marker.color}
         />
       ))}
     </Map>

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Map, CircleMarker, Popup, TileLayer } from 'react-leaflet';
 
-const position = [42.3947, -71.10548];
+const position = [42.3925, -71.10548];
 
 const MapMarker = ({ lat, lng, id, title, date, color }) => (
   <CircleMarker
@@ -27,11 +27,11 @@ const ExploreDataMap = ({ markers }) => (
   <>
     <style type="text/css">{`
       .leaflet-container {
-        height: 300px;
+        height: 350px;
         width: 100%;
       }
   `}</style>
-    <Map center={position} zoom={12}>
+    <Map center={position} zoom={13} scrollWheelZoom={false}>
       <TileLayer
         url="http://tiles.mapc.org/basemap/{z}/{x}/{y}.png"
         attribution='Tiles by <a href="http://mapc.org">MAPC</a>, Data by <a href="http://mass.gov/mgis">MassGIS</a>'

--- a/src/components/Permits/index.js
+++ b/src/components/Permits/index.js
@@ -11,7 +11,8 @@ import { fetchPermitsExploreData } from 'data/permits/actions';
 import {
   getMapData,
   getChartData,
-  getCategoryNames
+  getCategoryNames,
+  getLegendData
 } from 'data/permits/selectors';
 
 const categoryPresets = {
@@ -35,7 +36,8 @@ const Permits = ({
   params,
   mapData,
   fetchPermitsExploreData,
-  updatePermitsParams
+  updatePermitsParams,
+  legendData
 }) => (
   <DataBlock>
     <h2>Building Permits</h2>
@@ -58,6 +60,7 @@ const Permits = ({
       params={params}
       mapData={mapData}
       fetchData={fetchPermitsExploreData}
+      legendData={legendData}
     />
   </DataBlock>
 );
@@ -67,7 +70,8 @@ export default connect(
     selectedCategoryNames: getCategoryNames(state),
     chartData: getChartData(state),
     params: state.permits.exploreDataParams,
-    mapData: getMapData(state)
+    mapData: getMapData(state),
+    legendData: getLegendData(state)
   }),
   {
     fetchPermitsExploreData

--- a/src/components/PublicSafety/index.js
+++ b/src/components/PublicSafety/index.js
@@ -11,7 +11,8 @@ import { fetchPublicSafetyExploreData } from 'data/publicSafety/actions';
 import {
   getCategoryNames,
   getChartData,
-  getMapData
+  getMapData,
+  getLegendData
 } from 'data/publicSafety/selectors';
 
 const categoryPresets = {
@@ -30,7 +31,8 @@ const PublicSafety = ({
   params,
   mapData,
   fetchData,
-  updatePermitsParams
+  updatePermitsParams,
+  legendData
 }) => (
   <DataBlock>
     <h2>Public Safety</h2>
@@ -50,6 +52,7 @@ const PublicSafety = ({
       params={params}
       mapData={mapData}
       fetchData={fetchData}
+      legendData={legendData}
     />
   </DataBlock>
 );
@@ -59,7 +62,8 @@ export default connect(
     selectedCategoryNames: getCategoryNames(state),
     chartData: getChartData(state),
     params: state.publicSafety.exploreDataParams,
-    mapData: getMapData(state)
+    mapData: getMapData(state),
+    legendData: getLegendData(state)
   }),
   {
     fetchData: fetchPublicSafetyExploreData

--- a/src/data/cityWork/selectors.js
+++ b/src/data/cityWork/selectors.js
@@ -157,9 +157,23 @@ const getTicketsWithCategories = createSelector(
   }
 );
 
+const getTypesForChart = createSelector(
+  [getLegendTypes, typesByIdSelector],
+  (legendTypes, typesById) => {
+    return Object.keys(legendTypes).reduce((memo, typeId, index) => {
+      const type = legendTypes[typeId];
+      return {
+        ...memo,
+        [type.name]: type
+      };
+    }, {});
+  }
+);
+
 export const getChartData = createSelector(
-  [getTicketsWithCategories, getParams],
-  (tickets, params) => getStackedAreaChartData(tickets, params, 'created_on')
+  [getTicketsWithCategories, getParams, getTypesForChart],
+  (tickets, params, types) =>
+    getStackedAreaChartData(tickets, params, types, 'created_on')
 );
 
 export const getLegendData = createSelector(getLegendTypes, legendData);

--- a/src/data/cityWork/selectors.js
+++ b/src/data/cityWork/selectors.js
@@ -140,7 +140,7 @@ export const getCategoryNames = createSelector(getParams, params => {
   return params.categories;
 });
 
-export const getLegendTypes = createSelector(
+const getLegendTypes = createSelector(
   [getParams, getTicketsWithCategories, typesByIdSelector],
   (params, tickets, typesById) => {
     const currentSelectionTypes = groupBy(tickets, 'typeId');
@@ -158,6 +158,12 @@ export const getLegendTypes = createSelector(
     );
   }
 );
+
+export const getLegendData = createSelector(getLegendTypes, types => {
+  return Object.keys(types)
+    .map(id => types[id])
+    .sort((a, b) => b.count - a.count);
+});
 
 export const getMapData = createSelector(
   [getTicketsWithCategories, exploreDataKeySelector, getLegendTypes],
@@ -191,6 +197,8 @@ export const getInternalWeeklyTrends = createSelector(
     return selection;
   }
 );
+
+// TODO: audit selectors, see if any can be simplified/combined
 
 export const getInternalTreemapData = createSelector(
   weeklyTrendsSelector,

--- a/src/data/cityWork/selectors.js
+++ b/src/data/cityWork/selectors.js
@@ -16,6 +16,7 @@ import {
   getDateRange
 } from 'data/utils';
 import { isServiceRequest } from 'data/BaseCategories';
+import { CHART_COLORS_2 } from 'charts/Constants';
 
 const WORK_ORDERS_CREATED_CATEGORY = 9;
 const WORK_ORDERS_CLOSED_CATEGORY = 6;
@@ -95,24 +96,6 @@ export const getWorkOrderChartData = createSelector(
   }
 );
 
-export const getMapData = createSelector(
-  [exploreDataCacheSelector, exploreDataKeySelector, typesByIdSelector],
-  (exploreDataCache, exploreDataKey, typesById) => {
-    let selection = [];
-    if (exploreDataCache && exploreDataKey) {
-      selection = exploreDataCache.map(ticket => ({
-        id: ticket.id,
-        latitude: ticket.latitude,
-        longitude: ticket.longitude,
-        title: typesById[ticket.type] ? typesById[ticket.type].name : '',
-        date: format(parseISO(ticket.created_on), 'yyyy-MM-dd'),
-        type: typesById[ticket.type]
-      }));
-    }
-    return selection;
-  }
-);
-
 const getTicketsWithCategories = createSelector(
   [exploreDataCacheSelector, typesByIdSelector],
   (exploreDataCache, typesById) => {
@@ -151,6 +134,41 @@ export const getChartData = createSelector(
 export const getCategoryNames = createSelector(getParams, params => {
   return params.categories;
 });
+
+export const getCategoriesWithColors = createSelector(
+  [getParams, typesByIdSelector],
+  (params, typesById) => {
+    return Object.keys(typesById).reduce(
+      (memo, typeId, index) => ({
+        ...memo,
+        [typeId]: {
+          ...typesById[typeId],
+          color: CHART_COLORS_2[index % CHART_COLORS_2.length]
+        }
+      }),
+      {}
+    );
+  }
+);
+
+export const getMapData = createSelector(
+  [exploreDataCacheSelector, exploreDataKeySelector, getCategoriesWithColors],
+  (exploreDataCache, exploreDataKey, typesById) => {
+    let selection = [];
+    if (exploreDataCache && exploreDataKey) {
+      selection = exploreDataCache.map(ticket => ({
+        id: ticket.id,
+        latitude: ticket.latitude,
+        longitude: ticket.longitude,
+        title: typesById[ticket.type] ? typesById[ticket.type].name : '',
+        date: format(parseISO(ticket.created_on), 'yyyy-MM-dd'),
+        type: typesById[ticket.type],
+        color: typesById[ticket.type].color
+      }));
+    }
+    return selection;
+  }
+);
 
 export const getAllWeeklyTrends = createSelector(
   weeklyTrendsSelector,

--- a/src/data/permits/selectors.js
+++ b/src/data/permits/selectors.js
@@ -2,7 +2,12 @@ import { createSelector } from 'reselect';
 import format from 'date-fns/format';
 import parseISO from 'date-fns/parseISO';
 
-import { getStackedAreaChartData, legendData, groupBy } from 'data/utils';
+import {
+  getStackedAreaChartData,
+  selectionTypes,
+  legendData,
+  groupBy
+} from 'data/utils';
 import { CHART_COLORS_2 } from 'charts/Constants';
 
 const dailyTotalsSelector = state => state.permits.dailyTotals;
@@ -59,23 +64,7 @@ export const getCategoryNames = createSelector(getParams, params => {
 
 const getSelectionTypes = createSelector(
   [exploreDataCacheSelector, getCategoryNames],
-  (tickets, types) => {
-    const currentSelectionTypes = groupBy(tickets, 'type');
-
-    return Object.keys(currentSelectionTypes).reduce(
-      (memo, type, index) => ({
-        ...memo,
-        [type]: {
-          name: type,
-          count: currentSelectionTypes[type]
-            ? currentSelectionTypes[type].length
-            : 0,
-          color: CHART_COLORS_2[index % CHART_COLORS_2.length]
-        }
-      }),
-      {}
-    );
-  }
+  selectionTypes
 );
 
 export const getLegendData = createSelector(getSelectionTypes, legendData);

--- a/src/data/permits/selectors.js
+++ b/src/data/permits/selectors.js
@@ -70,8 +70,9 @@ const getSelectionTypes = createSelector(
 export const getLegendData = createSelector(getSelectionTypes, legendData);
 
 export const getChartData = createSelector(
-  [exploreDataCacheSelector, getParams],
-  (permits, params) => getStackedAreaChartData(permits, params, 'issue_date')
+  [exploreDataCacheSelector, getParams, getSelectionTypes],
+  (permits, params, types) =>
+    getStackedAreaChartData(permits, params, types, 'issue_date')
 );
 
 export const getMapData = createSelector(

--- a/src/data/publicSafety/selectors.js
+++ b/src/data/publicSafety/selectors.js
@@ -64,11 +64,12 @@ const getSelectionTypes = createSelector(
 export const getLegendData = createSelector(getSelectionTypes, legendData);
 
 export const getChartData = createSelector(
-  [exploreDataCacheSelector, getParams, getCategoryNames],
-  (permits, params, categoryNames) =>
+  [exploreDataCacheSelector, getParams, getCategoryNames, getSelectionTypes],
+  (permits, params, categoryNames, types) =>
     getStackedAreaChartData(
       permits,
       { ...params, categories: categoryNames },
+      types,
       'date'
     )
 );

--- a/src/data/publicSafety/selectors.js
+++ b/src/data/publicSafety/selectors.js
@@ -2,7 +2,12 @@ import { createSelector } from 'reselect';
 import parseISO from 'date-fns/parseISO';
 import format from 'date-fns/format';
 
-import { getStackedAreaChartData, groupBy } from 'data/utils';
+import {
+  getStackedAreaChartData,
+  selectionTypes,
+  legendData,
+  groupBy
+} from 'data/utils';
 
 const dailyTotalsSelector = state => state.publicSafety.dailyTotals;
 const typeAveragesSelector = state => state.publicSafety.typeAverages;
@@ -51,6 +56,13 @@ export const getCategoryNames = createSelector(
   }
 );
 
+const getSelectionTypes = createSelector(
+  [exploreDataCacheSelector, getCategoryNames],
+  selectionTypes
+);
+
+export const getLegendData = createSelector(getSelectionTypes, legendData);
+
 export const getChartData = createSelector(
   [exploreDataCacheSelector, getParams, getCategoryNames],
   (permits, params, categoryNames) =>
@@ -62,8 +74,8 @@ export const getChartData = createSelector(
 );
 
 export const getMapData = createSelector(
-  [exploreDataCacheSelector, exploreDataParamsSelector],
-  (exploreDataCache, exploreDataParams) => {
+  [exploreDataCacheSelector, exploreDataParamsSelector, getSelectionTypes],
+  (exploreDataCache, exploreDataParams, selectionTypes) => {
     let selection = [];
     if (exploreDataCache && exploreDataParams) {
       selection = exploreDataCache.map(incident => ({
@@ -72,7 +84,8 @@ export const getMapData = createSelector(
         longitude: incident.longitude,
         title: incident.type,
         date: format(parseISO(incident.date), 'yyyy-MM-dd'),
-        type: incident.type
+        type: incident.type,
+        color: selectionTypes[incident.type].color
       }));
       selection = selection.filter(
         incident => incident.latitude && incident.longitude

--- a/src/data/utils.js
+++ b/src/data/utils.js
@@ -5,6 +5,7 @@ import differenceInDays from 'date-fns/differenceInDays';
 import subDays from 'date-fns/subDays';
 
 import { SOCRATA_TIMESTAMP } from 'data/Constants';
+import { CHART_COLORS_2 } from 'charts/Constants';
 
 export const formatTimestamp = date => format(date, SOCRATA_TIMESTAMP);
 
@@ -66,6 +67,24 @@ export const getStackedAreaChartData = (data, params, dateField) => {
     }));
   }
   return chartData;
+};
+
+export const selectionTypes = (tickets, types) => {
+  const currentSelectionTypes = groupBy(tickets, 'type');
+
+  return Object.keys(currentSelectionTypes).reduce(
+    (memo, type, index) => ({
+      ...memo,
+      [type]: {
+        name: type,
+        count: currentSelectionTypes[type]
+          ? currentSelectionTypes[type].length
+          : 0,
+        color: CHART_COLORS_2[index % CHART_COLORS_2.length]
+      }
+    }),
+    {}
+  );
 };
 
 export const legendData = types =>

--- a/src/data/utils.js
+++ b/src/data/utils.js
@@ -38,25 +38,14 @@ export const getDateRange = ({ startDate, endDate }) => {
   return set;
 };
 
-export const dateRangeBuckets = ({ startDate, endDate }) => {
-  const set = {};
-  const start = startOfDay(startDate);
-  const end = startOfDay(endDate);
-  const size = differenceInDays(end, start);
-
-  for (let i = size; i >= 0; i--) {
-    set[formatTimestamp(subDays(end, i))] = null;
-  }
-  return set;
-};
-
 export const getStackedAreaChartData = (data, params, dateField) => {
   let chartData = { data: [], columns: [] };
   if (data && params) {
     const { categories, dateRange } = params;
-    let dataByDay = dateRangeBuckets(dateRange);
+    let dataByDay = {};
+    const range = getDateRange(dateRange);
 
-    Object.keys(dataByDay).forEach(key => {
+    range.forEach(key => {
       dataByDay[key] = categories.reduce(
         (memo, category) => ({
           ...memo,
@@ -66,19 +55,20 @@ export const getStackedAreaChartData = (data, params, dateField) => {
       );
     });
 
-    const orderedDates = Object.keys(dataByDay).sort((a, b) => {
-      return differenceInDays(parseISO(a), parseISO(b));
-    });
-
     data.forEach(ticket => {
       const dateKey = formatTimestamp(startOfDay(parseISO(ticket[dateField])));
       dataByDay[dateKey][ticket.type]++;
     });
-    chartData.columns = orderedDates;
-    chartData.data = orderedDates.map(day => ({
+    chartData.columns = range;
+    chartData.data = range.map(day => ({
       ...dataByDay[day],
       date: parseISO(day)
     }));
   }
   return chartData;
 };
+
+export const legendData = types =>
+  Object.keys(types)
+    .map(id => types[id])
+    .sort((a, b) => b.count - a.count);

--- a/src/data/utils.js
+++ b/src/data/utils.js
@@ -39,7 +39,7 @@ export const getDateRange = ({ startDate, endDate }) => {
   return set;
 };
 
-export const getStackedAreaChartData = (data, params, dateField) => {
+export const getStackedAreaChartData = (data, params, types, dateField) => {
   let chartData = { data: [], columns: [] };
   if (data && params) {
     const { categories, dateRange } = params;
@@ -47,7 +47,7 @@ export const getStackedAreaChartData = (data, params, dateField) => {
     const range = getDateRange(dateRange);
 
     range.forEach(key => {
-      dataByDay[key] = categories.reduce(
+      dataByDay[key] = Object.keys(types).reduce(
         (memo, category) => ({
           ...memo,
           [category]: 0
@@ -65,6 +65,7 @@ export const getStackedAreaChartData = (data, params, dateField) => {
       ...dataByDay[day],
       date: parseISO(day)
     }));
+    chartData.types = types;
   }
   return chartData;
 };

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -11,7 +11,7 @@ const IndexPage = () => (
   <Layout>
     <SEO title="Home" lang="en" />
     <CityWork />
-    {/*<PublicSafety />*/}
+    <PublicSafety />
     <Permits />
     {/*<CityWebsite />*/}
   </Layout>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -11,7 +11,7 @@ const IndexPage = () => (
   <Layout>
     <SEO title="Home" lang="en" />
     <CityWork />
-    <PublicSafety />
+    {/*<PublicSafety />*/}
     <Permits />
     {/*<CityWebsite />*/}
   </Layout>


### PR DESCRIPTION
This improves the appearance and functionality of the data explorer:

![image](https://user-images.githubusercontent.com/491289/73760841-ee9b0200-473b-11ea-9650-726cab16d744.png)

Now contains a legend, stacked bar chart instead of stacked area chart, tooltip on the bar chart, and map markers in colors matching their corresponding bar chart colors. The data explorer could still use some CSS help. Accessible naming PR will follow shortly.

Of note: our current chart color palette contains 18 colors pulled from d3's defaults. Views with greater than 18 categories selected (such as Parking) will contain repeat colors for different categories. This is a functionality bug -- planning to resolve (and address WCAG 1.4.1) by tagging categories with a rotating set of background patterns.

cc @yro / fyi @mmastrobuoni !