### PR TITLE
add category name mapping for public safety data

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ npm install
 npm run start
 ```
 
-5. View your local copy of the site at http://localhost:8000
+5. View your local copy of the site at http://localhost:8000.

--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ npm run start
 ```
 
 5. View your local copy of the site at http://localhost:8000.
+
+## Edit
+
+- To change category display names (such as for public safety), modify the file [CategoryNames.js](https://github.com/cityofsomerville/stat_dashboard_frontend/edit/master/src/data/CategoryNames.js).

--- a/src/components/CityWork/CityWorkKeyMetrics.js
+++ b/src/components/CityWork/CityWorkKeyMetrics.js
@@ -13,7 +13,7 @@ const CityWorkKeyMetrics = ({ created, closed, calls }) => (
       work orders closed
     </Metric>
     <Metric figure={calls.figure} average={calls.average}>
-      311 calls
+      311 reports
     </Metric>
   </KeyMetrics>
 );

--- a/src/data/CategoryNames.js
+++ b/src/data/CategoryNames.js
@@ -1,0 +1,63 @@
+/*
+  This file is used to set preferred display names for categories
+  from raw data sources. Each line is in the following format:
+
+  "RAW CATEGORY NAME": "Preferred display name",
+
+  The first string, to the left of the colon, is the "raw" category
+  name. The second string, to the right of the colon, is the desired
+  display name for that category.
+
+  To modify any existing display name mappings, simply edit the display
+  name for the category you want to change (or delete the line
+  entirely if you'd rather go back to the old name).
+
+  To add a new display name, add a new line to the object below in the
+  format described above. The new line can go anywhere inside the object,
+  as long as it's inside the {}. The raw category name must match the
+  category name from the data source exactly (case sensitive), but the
+  display name can be in any format you want. Both strings should be in
+  quotation marks. Make sure every line has a comma at the end.
+*/
+
+const CategoryNames = {
+  // Quality of Life
+  ANIMALS: 'Animals',
+  DRUGS: 'Drugs',
+  DRUNK: 'Drunk',
+  GROUPS: 'Groups',
+  'HYPO-FND': 'Hypo found',
+  'MV VANDL': 'Motor vehicle vandalism',
+  NOISE: 'Noise',
+  'NOISE/FW': 'Noise/FW',
+  'ROAD RAGE': 'Road rage',
+  UNWANTED: 'Unwanted',
+
+  // Criminal Incidents
+  'BURGLARY/BREAKING AND ENTERING': 'Burglary/breaking and entering',
+  'MOTOR VEHICLE THEFT': 'Motor vehicle theft',
+  ROBBERY: 'Robbery',
+  'THEFT FROM MOTOR VEHICLE': 'Theft from motor vehicle',
+
+  // Motor Vehicle Citations
+  'INSPECTION/STICKER, NO c90 S20': 'No inspection/sticker',
+  'LICENSE NOT IN POSSESSION c90 S11': 'License not in possession',
+  'LICENSE SUSPENDED, OP MV WITH c90 S23':
+    'Operating motor vehicle with license suspended',
+  'MARKED LANES VIOLATION c89 S4A': 'Marked lanes violation',
+  'OP MV WITH c90 S23': 'Operating motor vehicle with c90 S23',
+  'PASSING VIOLATION c89 S2': 'Passing violation',
+  'SAFETY STANDARDS, MV NOT MEETING RMV c90 S7A':
+    'Motor vehicle not meeting RMV safety standards',
+  'STOP/YIELD, FAIL TO c89 S9': 'Failure to stop/yield',
+  'UNSAFE OPERATION OF MV c90 S13': 'Unsafe operation of motor vehicle',
+
+  // Traffic enforcement
+  'MV STOP': 'Motor vehicle stop',
+  TRAFCOMP: 'Traffic comp',
+  TRESPTOW: 'Trespassing/towing',
+  PARKVIOL: 'Parking violation',
+  BOOTLIST: 'Boot list'
+};
+
+export default CategoryNames;

--- a/src/data/CategoryNames.js
+++ b/src/data/CategoryNames.js
@@ -20,44 +20,43 @@
   quotation marks. Make sure every line has a comma at the end.
 */
 
+// prettier-ignore
 const CategoryNames = {
   // Quality of Life
-  ANIMALS: 'Animals',
-  DRUGS: 'Drugs',
-  DRUNK: 'Drunk',
-  GROUPS: 'Groups',
-  'HYPO-FND': 'Hypo found',
-  'MV VANDL': 'Motor vehicle vandalism',
-  NOISE: 'Noise',
-  'NOISE/FW': 'Noise/FW',
-  'ROAD RAGE': 'Road rage',
-  UNWANTED: 'Unwanted',
+  "ANIMALS": "Animals",
+  "DRUGS": "Drugs",
+  "DRUNK": "Drunk",
+  "GROUPS": "Groups",
+  "HYPO-FND": "Hypo found",
+  "MV VANDL": "Motor vehicle vandalism",
+  "NOISE": "Noise",
+  "NOISE/FW": "Noise/FW",
+  "ROAD RAGE": "Road rage",
+  "UNWANTED": "Unwanted",
 
   // Criminal Incidents
-  'BURGLARY/BREAKING AND ENTERING': 'Burglary/breaking and entering',
-  'MOTOR VEHICLE THEFT': 'Motor vehicle theft',
-  ROBBERY: 'Robbery',
-  'THEFT FROM MOTOR VEHICLE': 'Theft from motor vehicle',
+  "BURGLARY/BREAKING AND ENTERING": "Burglary/breaking and entering",
+  "MOTOR VEHICLE THEFT": "Motor vehicle theft",
+  "ROBBERY": "Robbery",
+  "THEFT FROM MOTOR VEHICLE": "Theft from motor vehicle",
 
   // Motor Vehicle Citations
-  'INSPECTION/STICKER, NO c90 S20': 'No inspection/sticker',
-  'LICENSE NOT IN POSSESSION c90 S11': 'License not in possession',
-  'LICENSE SUSPENDED, OP MV WITH c90 S23':
-    'Operating motor vehicle with license suspended',
-  'MARKED LANES VIOLATION c89 S4A': 'Marked lanes violation',
-  'OP MV WITH c90 S23': 'Operating motor vehicle with c90 S23',
-  'PASSING VIOLATION c89 S2': 'Passing violation',
-  'SAFETY STANDARDS, MV NOT MEETING RMV c90 S7A':
-    'Motor vehicle not meeting RMV safety standards',
-  'STOP/YIELD, FAIL TO c89 S9': 'Failure to stop/yield',
-  'UNSAFE OPERATION OF MV c90 S13': 'Unsafe operation of motor vehicle',
+  "INSPECTION/STICKER, NO c90 S20": "No inspection/sticker",
+  "LICENSE NOT IN POSSESSION c90 S11": "License not in possession",
+  "LICENSE SUSPENDED, OP MV WITH c90 S23": "Operating motor vehicle with license suspended",
+  "MARKED LANES VIOLATION c89 S4A": "Marked lanes violation",
+  "OP MV WITH c90 S23": "Operating motor vehicle with c90 S23",
+  "PASSING VIOLATION c89 S2": "Passing violation",
+  "SAFETY STANDARDS, MV NOT MEETING RMV c90 S7A": "Motor vehicle not meeting RMV safety standards",
+  "STOP/YIELD, FAIL TO c89 S9": "Failure to stop/yield",
+  "UNSAFE OPERATION OF MV c90 S13": "Unsafe operation of motor vehicle",
 
   // Traffic enforcement
-  'MV STOP': 'Motor vehicle stop',
-  TRAFCOMP: 'Traffic comp',
-  TRESPTOW: 'Trespassing/towing',
-  PARKVIOL: 'Parking violation',
-  BOOTLIST: 'Boot list'
+  "MV STOP": "Motor vehicle stop",
+  "TRAFCOMP": "Traffic comp",
+  "TRESPTOW": "Trespassing/towing",
+  "PARKVIOL": "Parking violation",
+  "BOOTLIST": "Boot list",
 };
 
 export default CategoryNames;

--- a/src/data/publicSafety/selectors.js
+++ b/src/data/publicSafety/selectors.js
@@ -8,6 +8,7 @@ import {
   legendData,
   groupBy
 } from 'data/utils';
+import CategoryNames from 'data/CategoryNames';
 
 const dailyTotalsSelector = state => state.publicSafety.dailyTotals;
 const typeAveragesSelector = state => state.publicSafety.typeAverages;
@@ -49,22 +50,31 @@ const getParams = createSelector(
   }
 );
 
-export const getCategoryNames = createSelector(
+const getCategoryCorrectedData = createSelector(
   exploreDataCacheSelector,
+  exploreDataCache =>
+    exploreDataCache.map(incident => ({
+      ...incident,
+      type: CategoryNames[incident.type] || incident.type
+    }))
+);
+
+export const getCategoryNames = createSelector(
+  getCategoryCorrectedData,
   exploreDataCache => {
     return Object.keys(groupBy(exploreDataCache, 'type'));
   }
 );
 
 const getSelectionTypes = createSelector(
-  [exploreDataCacheSelector, getCategoryNames],
+  [getCategoryCorrectedData, getCategoryNames],
   selectionTypes
 );
 
 export const getLegendData = createSelector(getSelectionTypes, legendData);
 
 export const getChartData = createSelector(
-  [exploreDataCacheSelector, getParams, getCategoryNames, getSelectionTypes],
+  [getCategoryCorrectedData, getParams, getCategoryNames, getSelectionTypes],
   (permits, params, categoryNames, types) =>
     getStackedAreaChartData(
       permits,
@@ -75,7 +85,7 @@ export const getChartData = createSelector(
 );
 
 export const getMapData = createSelector(
-  [exploreDataCacheSelector, exploreDataParamsSelector, getSelectionTypes],
+  [getCategoryCorrectedData, exploreDataParamsSelector, getSelectionTypes],
   (exploreDataCache, exploreDataParams, selectionTypes) => {
     let selection = [];
     if (exploreDataCache && exploreDataParams) {


### PR DESCRIPTION
This adds a file CategoryNames.js and some logic for mapping raw public safety category names to preferred display names. I added some placeholder display names just to show it working, but these mappings can be added, removed, or modified as necessary.